### PR TITLE
Heapify up when deleting node (possibly needed if the last element is larger)

### DIFF
--- a/index.civet
+++ b/index.civet
@@ -651,6 +651,7 @@ class SpriteTree
         n.animMove n.x! - direction * xSpace / 2, n.y!
     await @draw true
     await @animMaxHeapifyDown node
+    await @animMaxHeapifyUp node
     @draw()
 
   animMaxHeapDelete(key: number): Promise<void>


### PR DESCRIPTION
With Max Heap selected, run `b 8 7 3 5 6 2 1 4` and `d 2`. The resulting tree does not satisfy the max-heap property since 3 is now the parent of 4.

This PR fixes it by running animMaxHeapifyUp in the animMaxHeapDelete subroutine. 